### PR TITLE
Create a new client for each bind.

### DIFF
--- a/lib/passport-ldapbind/strategy.js
+++ b/lib/passport-ldapbind/strategy.js
@@ -13,8 +13,6 @@ function Strategy(options, verify) {
     this.name = 'ldapBind';
     this.options = options;
     this.verify = verify;
-
-    this.client = ldap.createClient(this.options.server);
 }
 
 util.inherits(Strategy, passport.Strategy);
@@ -45,7 +43,10 @@ Strategy.prototype.authenticate = function(req) {
         return retry('password required');
     }
 
-    self.client.bind(username, password, function (err, user) {
+    var client = ldap.createClient(this.options.server);
+
+    client.bind(username, password, function (err, user) {
+        client.unbind();
         if (err) {
             if (err.name === 'InvalidCredentialsError' || err.name === 'NoSuchObjectError' || (typeof err === 'string' && err.match(/no such user/i))) {
                 return self.fail('Invalid username/password');


### PR DESCRIPTION
Reusing a single client is stateful and therefore fragile. If a
temporary loss of connection to the LDAP server occurs, all following
authentication attempts result in a "write after end" error, the only
solution to which is to restart the application.
